### PR TITLE
RadioInputs not using @handleChange

### DIFF
--- a/modules/components/forms/radio_input.cjsx
+++ b/modules/components/forms/radio_input.cjsx
@@ -37,7 +37,7 @@ module.exports = class RadioInput extends RestFormElement
           value={option.value}
           disabled={option.disabled}
           type='radio'
-          onChange={@props.onChange} />
+          onChange={@handleChange} />
         {option.name}
         <br/>
       </label>


### PR DESCRIPTION
Seems to have snuck in a previous PR, but the component wasn’t using RestFormElement’s @handleChange function. It was using the passed in prop which was causing all types of chaos.
