### PR TITLE
Store#destroyResource resource ID argument

### DIFF
--- a/modules/store.coffee
+++ b/modules/store.coffee
@@ -215,7 +215,7 @@ class Store
     @delete(url)
       .then (data) =>
         @unstoreResource id
-        @trigger 'destroy', @resources
+        @trigger 'destroy', @resources, id
 
 
   # Given the raw AJAX data, return the associated policies


### PR DESCRIPTION
Depending on how you're listening to events on a Store, you might want to listen for `destroy` events, but that event only contains the resources that are still left in the Store.  Adding an id argument onto the event allows for various interfaces to remove the item if they need it.